### PR TITLE
build: :construction_worker: removes per-file ignores from ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,17 +4,9 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - "**/README.md"
-      - "**/LICENSE.txt"
-      - ".vscode/*"
   push:
     branches:
       - main
-    paths-ignore:
-      - "**/README.md"
-      - "**/LICENSE.txt"
-      - ".vscode/*"
 jobs:
   build:
     name: Build Docker image and run end-to-end tests


### PR DESCRIPTION
Per-file ignores in CI conflicts with branch protection rules and need to be removed.